### PR TITLE
Increased log level to lifecycle and added more logging on update

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/versioneye/CreateTask.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/versioneye/CreateTask.groovy
@@ -74,7 +74,7 @@ class CreateTask extends DefaultTask {
 			  def projectKey = json.project_key
 			  def projectId = json.id
 			  assert projectKey, 'Project key could not be determined from response'
-			  project.logger.info "Project created with project key $projectKey"
+			  project.logger.lifecycle "Project created with project key $projectKey"
 			  
 			  // save project key in properties
 			  Properties props = new Properties()
@@ -95,8 +95,8 @@ class CreateTask extends DefaultTask {
 			  }
 			  project.logger.warn 'Saved project key to ' + propertiesFile.name 
 			  
-			  json.dep_number?.with{ project.logger.info "$it dependencies overall" }
-			  json.out_number?.with{ project.logger.info "$it outdated dependencies" }
+			  json.dep_number?.with{ project.logger.lifecycle "$it dependencies overall" }
+			  json.out_number?.with{ project.logger.lifecycle "$it outdated dependencies" }
 		  }
 		}
 	}

--- a/src/main/groovy/org/standardout/gradle/plugin/versioneye/UpdateTask.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/versioneye/UpdateTask.groovy
@@ -66,9 +66,16 @@ class UpdateTask extends DefaultTask {
 		  response.success = {
 			  resp, json ->
 			  assert json, 'Invalid response'
-			  project.logger.info 'Updated VersionEye project successfully'
-			  json.dep_number?.with{ project.logger.info "$it dependencies overall" }
-			  json.out_number?.with{ project.logger.info "$it outdated dependencies" } 
+			  project.logger.lifecycle "Updated VersionEye project $json.name successfully"
+			  json.dependencies?.each {
+				if (it.outdated) {
+					project.logger.lifecycle "Consider updating $it.name from $it.version_requested to $it.version_current"
+				} else if (!it.unknown) {
+					project.logger.lifecycle "$it.name is up-to-date"
+				}
+			  }
+			  json.dep_number?.with{ project.logger.lifecycle "$it dependencies overall" }
+			  json.out_number?.with{ project.logger.lifecycle "$it outdated dependencies" }
 		  }
 		}
 	}


### PR DESCRIPTION
The log level was `info` before which caused gradle to eat them by default. I increased the level of the major messages to `lifecycle` to get the most important feedback (useful for automated build logs).

I also added some more detailed logging on the `info` level. I'm not a groovy expert, but I guess a few things could be done easier (or shorter at least). Maybe similar logging could be done in CreateTask? - not overly important for my use case, though)
