### PR TITLE
Log up-to-date deps. on info level

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/versioneye/Util.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/versioneye/Util.groovy
@@ -40,7 +40,7 @@ class Util {
       if (it.outdated) {
         project.logger.lifecycle "Consider updating $it.name from $it.version_requested to $it.version_current"
       } else if (!it.unknown) {
-        project.logger.lifecycle "$it.name is up-to-date"
+        project.logger.info "$it.name is up-to-date"
       }
     }
     json.dep_number?.with{ project.logger.lifecycle "$it dependencies overall" }


### PR DESCRIPTION
It looks like the fix is as simple as reducing the log level to `INFO` for up-to-date entries.

Fixes #26 