### PR TITLE
Report unknown dependencies

### DIFF
--- a/src/main/groovy/org/standardout/gradle/plugin/versioneye/Util.groovy
+++ b/src/main/groovy/org/standardout/gradle/plugin/versioneye/Util.groovy
@@ -45,7 +45,8 @@ class Util {
     }
     json.dep_number?.with{ project.logger.lifecycle "$it dependencies overall" }
     json.out_number?.with{ project.logger.lifecycle "$it outdated dependencies" }
-
+    json.unknown_number_sum?.with{ if (it > 0) project.logger.lifecycle "$it unknown dependencies" }
+	
     // cache result for further analysis
     project.versioneye.lastVersionEyeResponse = json
   }


### PR DESCRIPTION
This PR will make the plugin report the number unknown dependencies, if they exist.

Remarks:
* Maybe there's a more elegant way to achieve this is groovy
* The flag ends with `_sum`. There is also `dep_number_sum` and `out_number_sum`. Maybe they should be used? I can't find a real spec. of the return value to verify.